### PR TITLE
Fix Bug with HumanReadableSize Function

### DIFF
--- a/src/CloudinaryEngine.php
+++ b/src/CloudinaryEngine.php
@@ -379,11 +379,11 @@ class CloudinaryEngine
     private function getHumanReadableSize($sizeInBytes)
     {
         if ($sizeInBytes >= 1073741824) {
-            return number_format($bytes / 1073741824, 2) . ' GB';
+            return number_format($sizeInBytes / 1073741824, 2) . ' GB';
         } elseif ($sizeInBytes >= 1048576) {
-            return number_format($bytes / 1048576, 2) . ' MB';
+            return number_format($sizeInBytes / 1048576, 2) . ' MB';
         } elseif ($sizeInBytes >= 1024) {
-            return number_format($bytes / 1024, 2) . ' KB';
+            return number_format($sizeInBytes / 1024, 2) . ' KB';
         } elseif ($sizeInBytes > 1) {
             return $sizeInBytes . ' bytes';
         } elseif ($sizeInBytes == 1) {


### PR DESCRIPTION
Fix bug with an undefined variable in `getHumanReadableSize` function of `CloudinaryEngine` class