### PR TITLE
CloudinaryAdapter fixes

### DIFF
--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -9,7 +9,6 @@ use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
 use Illuminate\Support\Str;
 
-
 /**
  * Class CloudinaryAdapter
  * @package CloudinaryLabs\CloudinaryLaravel
@@ -228,7 +227,12 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function has($path)
     {
-        return file_exists($path);
+        try {
+            $this->adminApi()->asset($path);
+        } catch (NotFound $e) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -266,8 +270,7 @@ class CloudinaryAdapter implements AdapterInterface
      * List contents of a directory.
      *
      * @param string $directory
-     * @param bool $hasR          ecursive
-     *
+     * @param bool $hasRecursive
      * @return array
      */
     public function listContents($directory = '', $hasRecursive = false)

--- a/src/CloudinaryAdapter.php
+++ b/src/CloudinaryAdapter.php
@@ -244,7 +244,7 @@ class CloudinaryAdapter implements AdapterInterface
      */
     public function read($path)
     {
-        $resource = (array)$this->adminApi()->resource($path);
+        $resource = (array)$this->adminApi()->asset($path);
         $contents = file_get_contents($resource['secure_url']);
 
         return compact('contents', 'path');


### PR DESCRIPTION
- Implements the CloudinaryAdapter::has() method
- Fixes reference to old SDK function.

related to: https://github.com/cloudinary-labs/cloudinary-laravel/issues/34